### PR TITLE
Add back button to project detail page

### DIFF
--- a/client/src/modules/home/modules/project/v1/index.tsx
+++ b/client/src/modules/home/modules/project/v1/index.tsx
@@ -24,6 +24,7 @@ import { OutputBlockData } from '@editorjs/editorjs';
 import { CommentsWrapperAtom } from '../../../../../shared/components/organisms/comments-wrapper/states';
 import A2ZTypography from '../../../../../shared/components/atoms/typography';
 import Header from '../../../../../shared/components/organisms/header';
+import A2ZIconButton from '../../../../../shared/components/atoms/icon-button';
 
 const Project = () => {
   const { project_id } = useParams();
@@ -47,27 +48,18 @@ const Project = () => {
 
   return (
     <>
-      {commentsWrapper && <CommentsWrapper />}      
+      {commentsWrapper && <CommentsWrapper />}
+      
       <Header
         leftSideChildren={
-          <Box
-            onClick={() => navigate(-1)}
-            sx={{
-              display: 'flex',
-              alignItems: 'center',
-              cursor: 'pointer',
-              '&:hover': {
-                opacity: 0.7,
-              },
+          <A2ZIconButton
+            props={{
+              onClick: () => navigate(-1),
+              'aria-label': 'Go back',
             }}
           >
-            <ArrowBackIcon
-              sx={{
-                fontSize: 32,
-                color: 'text.primary',
-              }}
-            />
-          </Box>
+            <ArrowBackIcon />
+          </A2ZIconButton>
         }
       />
 


### PR DESCRIPTION
### Pull Requests Review Criteria

> [!CAUTION]
> PRs that fail to meet these review standards will be automatically flagged and may be rejected by maintainers.

- [x] Filled out this PR template properly
- [x] Did **not** commit directly to `main`
- [x] Limited commits (max 3–4 unless permitted by Admin/Mentors)
- [x] Added comments in complex parts of code

Closes: #1369 


### Describe the add-ons or changes you've made 📃

Added a back button to the project detail page to allow users to navigate back to the previous page.

**Changes made:**
- Imported `useNavigate` hook from react-router-dom and `ArrowBackIcon` from Material-UI icons
- Added `navigate` hook inside the Project component
- Created a back button in the header section next to the project title
- Used `navigate(-1)` to go back to previous page in browser history
- Button uses outlined variant to match the existing design system

**Location of changes:**
- File: `client/src/modules/code/Project.tsx`
- Section: Header section where project title is displayed

This solves the issue where users had no way to exit the project page without using browser controls.

### Screenshots 📷

<img width="1920" height="841" alt="image" src="https://github.com/user-attachments/assets/a486a570-8a80-4ab2-a285-d344b8fd08f0" />

### Note to reviewers (Optional) 📄

<!-- Add notes to reviewers if applicable -->
